### PR TITLE
Fix spec_dir lookup when Dir.pwd is not Rails.root

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -23,7 +23,7 @@ module JasmineRails
 
     def spec_dir
       paths = jasmine_config['spec_dir'] || 'spec/javascripts'
-      [paths].flatten.map { |path| Dir.glob path }.flatten.collect { |path| Rails.root.join(path) }
+      [paths].flatten.map { |path| Dir.glob(Rails.root.join(path)) }.flatten.collect { |path| Rails.root.join(path) }
     end
 
     def include_dir


### PR DESCRIPTION
**Context**

I was able to get this gem to work with my engine by going
inside the `test_app` dir and running

`bundle exec rails spec:javascript`

So far so good. The problem is that I don't want to have to run
`cd spec/test_app` every time to run my Javascript tests. I want to run them
from the engine's grandparent directory so I can include it in my Rakefile for
the entire test suite. In other words, this is my dir tree:

```
~/engine/
~/engine/spec/javascripts/
~/engine/spec/test_app/spec/javascripts/support/jasmine.yml
```

`Rails.root` is always `~/engine/spec/test_app/`, regardless of whether
I'm in `~/engine/ or not.

**The problem**

Look at this line:

```rb
[paths].flatten.map { |path| Dir.glob path }.flatten.collect { |path| Rails.root.join(path) }
```

`Dir.glob path`, equivalent to `Dir.glob("spec/javascripts")` returns
`true` because `Dir.pwd` is `~/engine/`, therefore
`~/engine/spec/javascripts` exists.

However, the last `collect` has `Rails.root.join("spec_javascript)`,
which will map to `~/engine/spec/test_app/spec/javascripts`, but
there's nothing there (because my test files were configured to
`~/engine/spec/javascript`).

To "fix that, I put `../javascripts` in my yml's `spec_dir`, but no `Dir.glob`
just returns false because, in fact, `~/engine/../javascripts` doesn't exist.
So, the code is verifying one path and resolving to some other.

**The fix**

```patch
-      [paths].flatten.map { |path| Dir.glob path }.flatten.collect { |path| Rails.root.join(path) }
+      [paths].flatten.map { |path| Dir.glob(Rails.root.join(path)) }.flatten.collect { |path| Rails.root.join(path) }
```

This fix just makes it cohesive.

I suspect this is in a way connected with
https://github.com/searls/jasmine-rails/issues/102 (to make it work with
engines).